### PR TITLE
Specified utils to import

### DIFF
--- a/src/slate/classes.py
+++ b/src/slate/classes.py
@@ -22,7 +22,7 @@ try:
     from pdfminer.pdfparser import PDFPage
 except ImportError:
     from pdfminer.pdfpage import PDFPage
-import utils
+import slate.utils
 
 __all__ = ['PDF']
 


### PR DESCRIPTION
Changed import utils to import slate.utils... Was seeing issues when creating applications where it could not find slate.utils. I was changing in mine so that the PYTHONPATH included this, but I think maybe it should be specified? Not sure though... Thoughts?
